### PR TITLE
Automatically remove empty reagents

### DIFF
--- a/UnityProject/Assets/Scripts/Chemistry/ChemistryInitializationTest.cs
+++ b/UnityProject/Assets/Scripts/Chemistry/ChemistryInitializationTest.cs
@@ -26,7 +26,6 @@ public class ChemistryInitializationTest : MonoBehaviour
 			}
 			var Temperature = reactions [i].MinimumTemperature;
 			var ReturnedResults = Calculations.Reactions (RequiredReagents, Temperature);
-			ReturnedResults = Calculations.RemoveEmptyReagents(ReturnedResults);
 
 			foreach (string reagent in reactions[i].Results.Keys) {
 				if (ReturnedResults.ContainsKey (reagent)) {

--- a/UnityProject/Assets/Scripts/Chemistry/ReactionLib.cs
+++ b/UnityProject/Assets/Scripts/Chemistry/ReactionLib.cs
@@ -101,6 +101,9 @@ public static class Calculations
 		{
 			DoReaction(modifiedReagents, reaction);
 		}
+
+		RemoveEmptyReagents(modifiedReagents);
+
 		return modifiedReagents;
 	}
 

--- a/UnityProject/Assets/Scripts/Chemistry/ReagentContainer.cs
+++ b/UnityProject/Assets/Scripts/Chemistry/ReagentContainer.cs
@@ -37,7 +37,6 @@ public class ReagentContainer : Container {
 		}
 		float oldCapacity = CurrentCapacity;
 		Contents = Calculations.Reactions(Contents, Temperature);
-		Contents = Calculations.RemoveEmptyReagents(Contents);
 		CurrentCapacity = AmountOfReagents(Contents);
 		totalToAdd = ((CurrentCapacity - oldCapacity) * temperatureContainer) + (oldCapacity * Temperature);
 		Temperature = totalToAdd / CurrentCapacity;


### PR DESCRIPTION
### Purpose
Changes it so it is not required to call `RemoveEmptyReagents` after every `Reactions` call.

### Open Questions and Pre-Merge TODOs

- [ ]  This fix is tested on the same branch it is PR'ed to.
- [x]  I correctly commented my code
- [x]  My code is indented with tabs and not spaces
- [x]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [ ]  This PR does not bring up any new compile errors
- [ ]  This PR has been tested in editor
- [ ]  This PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)